### PR TITLE
Enable Gitlab Pages and Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Start Gitlab
 Register runner
 ```
 $EDITOR env.local  # set proper GITLAB_TOKEN after first startup
+./docker-compose-wrapper.sh restart gitlab-runner
 ./register-runner
 ```
 
@@ -106,7 +107,7 @@ vagrant reload
 vagrant provision
 ```
 
-One time manual instruction after first `vagrant up`
+One time manual instruction after first `vagrant up`:
 ```
 # Get into VM
 vagrant ssh
@@ -116,5 +117,6 @@ cd /vagrant/
 
 # Register runner
 $EDITOR env.local  # set proper GITLAB_TOKEN after first startup
+./docker-compose-wrapper.sh restart gitlab-runner
 ./register-runner
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # gitlab-ce-deploy
 Deploy gitlab-ce using docker-compose
 
+## Prerequite
+
+* Gitlab Pages needs "wildcard DNS" to be setup for this Gitlab host, see
+https://docs.gitlab.com/ee/administration/pages/index.html#dns-configuration.
+
+  Basically, we need `<any subdomains>.HOSTNAME_FQDN` to point to the same IP
+  as `HOSTNAME_FQDN`. `HOSTNAME_FQDN` is the hostname of this Gitlab host and
+  is set in `env.local` file.
+
 ## Usage
 
 Ensure you have [docker](https://www.docker.com/) and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # gitlab-ce-deploy
 Deploy gitlab-ce using docker-compose
 
+
 ## Prerequite
+
+* Ensure you have [docker](https://www.docker.com/) and
+  [docker-compose](https://docs.docker.com/compose/) installed on your Linux
+  host.
 
 * Gitlab Pages needs "wildcard DNS" to be setup for this Gitlab host, see
 https://docs.gitlab.com/ee/administration/pages/index.html#dns-configuration.
@@ -10,11 +15,8 @@ https://docs.gitlab.com/ee/administration/pages/index.html#dns-configuration.
   as `HOSTNAME_FQDN`. `HOSTNAME_FQDN` is the hostname of this Gitlab host and
   is set in `env.local` file.
 
-## Usage
 
-Ensure you have [docker](https://www.docker.com/) and
-[docker-compose](https://docs.docker.com/compose/) installed on your Linux
-host.
+## Usage
 
 One time setup
 ```
@@ -27,7 +29,7 @@ Start Gitlab
 ./docker-compose-wrapper.sh up -d
 ```
 
-Register runner
+Register runner once only, after first startup
 ```
 $EDITOR env.local  # set proper GITLAB_TOKEN after first startup
 ./docker-compose-wrapper.sh restart gitlab-runner
@@ -127,7 +129,7 @@ vagrant ssh
 # Go to workdir
 cd /vagrant/
 
-# Register runner
+# Register runner only only, after first startup
 $EDITOR env.local  # set proper GITLAB_TOKEN after first startup
 ./docker-compose-wrapper.sh restart gitlab-runner
 ./register-runner

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Access Gitlab at
 http://${HOSTNAME_FQDN},
 those variables are from your customized `env.local` file.
 
+Access Gitlab Pages at http://\<USER or GROUP\>.${HOSTNAME_FQDN}/\<REPO\>.
+Remember to trigger the pipeline for the pages to be generated properly.
+
 `docker-compose-wrapper.sh` is just a wrapper around `docker-compose` so all valid
 docker-compose use-cases and command-line options are supported.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ vagrant ssh
 # Go to workdir
 cd /vagrant/
 
-# Register runner only only, after first startup
+# Register runner once only, after first startup
 $EDITOR env.local  # set proper GITLAB_TOKEN after first startup
 ./docker-compose-wrapper.sh restart gitlab-runner
 ./register-runner

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Start Gitlab
 ./docker-compose-wrapper.sh up -d
 ```
 
+Register runner
+```
+$EDITOR env.local  # set proper GITLAB_TOKEN after first startup
+./register-runner
+```
+
+
 Access Gitlab at
 http://${HOSTNAME_FQDN},
 those variables are from your customized `env.local` file.
@@ -97,4 +104,17 @@ vagrant reload
 # maybe because it was provisioned too long ago, to the latest state.
 # not needed normally during tight development loop
 vagrant provision
+```
+
+One time manual instruction after first `vagrant up`
+```
+# Get into VM
+vagrant ssh
+
+# Go to workdir
+cd /vagrant/
+
+# Register runner
+$EDITOR env.local  # set proper GITLAB_TOKEN after first startup
+./register-runner
 ```

--- a/config/runner/.gitignore
+++ b/config/runner/.gitignore
@@ -1,0 +1,1 @@
+config.toml

--- a/config/runner/config.toml.template
+++ b/config/runner/config.toml.template
@@ -1,0 +1,22 @@
+# https://docs.gitlab.com/runner/configuration/advanced-configuration.html
+
+concurrent = 4
+check_interval = 0
+
+[session_server]
+  session_timeout = 1800
+
+[[runners]]
+  name = "docker-runner"
+  url = "${GITLAB_WEB_URL}"
+  token = "${GITLAB_TOKEN}"
+  executor = "docker"
+  [runners.docker]
+    tls_verify = false
+    image = "alpine:latest"
+    privileged = false
+    disable_entrypoint_overwrite = false
+    oom_kill_disable = false
+    disable_cache = false
+    volumes = ["/cache"]
+    shm_size = 0

--- a/config/runner/config.toml.template
+++ b/config/runner/config.toml.template
@@ -7,7 +7,7 @@ check_interval = 0
   session_timeout = 1800
 
 [[runners]]
-  name = "docker-runner"
+  name = "docker-runner1"
   url = "${GITLAB_WEB_URL}"
   token = "${GITLAB_TOKEN}"
   executor = "docker"

--- a/docker-compose-wrapper.sh
+++ b/docker-compose-wrapper.sh
@@ -8,6 +8,8 @@ NORMAL=$(tput sgr0)
 VARS='
   $HOSTNAME_FQDN
   $INITIAL_ROOT_PASSWORD
+  $GITLAB_WEB_URL
+  $GITLAB_TOKEN
 '
 
 # list of vars to be substituted in template but they do not have to be set in
@@ -40,12 +42,12 @@ then
 fi
 
 ## we apply all the templates
-#find ./config -name '*.template' -print0 |
-#  while IFS= read -r -d $'\0' FILE
-#  do
-#    DEST=${FILE%.template}
-#    cat ${FILE} | envsubst "$VARS" | envsubst "$OPTIONAL_VARS" > ${DEST}
-#  done
+find ./config -name '*.template' -print0 |
+  while IFS= read -r -d $'\0' FILE
+  do
+    DEST=${FILE%.template}
+    cat ${FILE} | envsubst "$VARS" | envsubst "$OPTIONAL_VARS" > ${DEST}
+  done
 
 if [[ $1 == "up" ]]; then
   # no error if already exist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
         pages_external_url 'http://${HOSTNAME_FQDN}'
         pages_nginx['redirect_http_to_https'] = false
         gitlab_pages['inplace_chroot'] = true
-        gitlab_pages['http_proxy'] = 'http://${HOSTNAME_FQDN}:8080'
-        gitlab_pages['listen_proxy'] = "${HOSTNAME_FQDN}:10080"
 
         # rather not take over the really ssh port 22 of the host
         # still need for ssh connection to the host for administration
@@ -36,8 +34,6 @@ services:
 
     ports:
       - '80:80'
-      - '8080:8080'
-      - '10080:10080'
       - '443:443'
       - '2224:22'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,13 @@ services:
       - 'gitlab_logs_persistence:/var/log/gitlab'
       - 'gitlab_data_persistence:/var/opt/gitlab'
 
+  runner:
+    image: 'gitlab/gitlab-runner'
+    restart: always
+    volumes:
+      - '/srv/gitlab-runner/config:/etc/gitlab-runner:rw'
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+
 volumes:
   gitlab_data_persistence:
     external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         external_url 'http://${HOSTNAME_FQDN}'
 
         # https://docs.gitlab.com/12.10/ee/administration/pages/index.html#wildcard-domains
+        # pages will be available at http://<USER or GROUP>.${HOSTNAME_FQDN}/<REPO>
         pages_external_url 'http://${HOSTNAME_FQDN}'
         pages_nginx['redirect_http_to_https'] = false
         gitlab_pages['inplace_chroot'] = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   web:
     image: 'gitlab/gitlab-ce:12.5.4-ce.0'
+    container_name: gitlab-web
     restart: always
     hostname: "${HOSTNAME_FQDN}"
     environment:
@@ -43,6 +44,7 @@ services:
 
   runner:
     image: 'gitlab/gitlab-runner:v14.7.0'
+    container_name: gitlab-runner
     restart: always
     volumes:
       - './config/runner/config.toml:/etc/gitlab-runner/config.toml:ro'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,14 @@ services:
       # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://${HOSTNAME_FQDN}'
+
+        # https://docs.gitlab.com/12.10/ee/administration/pages/index.html#wildcard-domains
+        pages_external_url 'http://${HOSTNAME_FQDN}'
+        pages_nginx['redirect_http_to_https'] = false
+        gitlab_pages['inplace_chroot'] = true
+        gitlab_pages['http_proxy'] = 'http://${HOSTNAME_FQDN}:8080'
+        gitlab_pages['listen_proxy'] = "${HOSTNAME_FQDN}:10080"
+
         # rather not take over the really ssh port 22 of the host
         # still need for ssh connection to the host for administration
         gitlab_rails['gitlab_shell_ssh_port'] = 2224
@@ -28,6 +36,8 @@ services:
 
     ports:
       - '80:80'
+      - '8080:8080'
+      - '10080:10080'
       - '443:443'
       - '2224:22'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 # https://docs.gitlab.com/omnibus/docker/README.html#install-gitlab-using-docker-compose
 services:
-  web:
+  gitlab-web:
     image: 'gitlab/gitlab-ce:12.5.4-ce.0'
     container_name: gitlab-web
     restart: always
@@ -42,7 +42,7 @@ services:
       - 'gitlab_logs_persistence:/var/log/gitlab'
       - 'gitlab_data_persistence:/var/opt/gitlab'
 
-  runner:
+  gitlab-runner:
     image: 'gitlab/gitlab-runner:v14.7.0'
     container_name: gitlab-runner
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,10 @@ services:
       - 'gitlab_data_persistence:/var/opt/gitlab'
 
   runner:
-    image: 'gitlab/gitlab-runner'
+    image: 'gitlab/gitlab-runner:v14.7.0'
     restart: always
     volumes:
-      - '/srv/gitlab-runner/config:/etc/gitlab-runner:rw'
+      - './config/runner/config.toml:/etc/gitlab-runner/config.toml:ro'
       - '/var/run/docker.sock:/var/run/docker.sock:ro'
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     container_name: gitlab-runner
     restart: always
     volumes:
-      - './config/runner/config.toml:/etc/gitlab-runner/config.toml:ro'
+      - './config/runner/config.toml:/etc/gitlab-runner/config.toml:rw'
       - '/var/run/docker.sock:/var/run/docker.sock:ro'
 
 volumes:

--- a/env.local.example
+++ b/env.local.example
@@ -13,7 +13,7 @@ export INITIAL_ROOT_PASSWORD="rootpasswd"
 export GITLAB_WEB_URL="http://${HOSTNAME_FQDN}"
 
 # For runner to connect to.
-# Token can be found at ${GITLAB_WEB_URL}/admin/runners
+# Token can be found at ${GITLAB_WEB_URL}/admin/runners, login using root account.
 #
 # On first startup this field can be left with bogus value since this is needed
 # for register-runner only which is run only after first start-up.

--- a/env.local.example
+++ b/env.local.example
@@ -14,6 +14,9 @@ export GITLAB_WEB_URL="http://${HOSTNAME_FQDN}"
 
 # For runner to connect to.
 # Token can be found at ${GITLAB_WEB_URL}/admin/runners
+#
+# On first startup this field can be left with bogus value since this is needed
+# for register-runner only which is run only after first start-up.
 export GITLAB_TOKEN="TOKEN"
 
 

--- a/env.local.example
+++ b/env.local.example
@@ -13,6 +13,7 @@ export INITIAL_ROOT_PASSWORD="rootpasswd"
 export GITLAB_WEB_URL="http://${HOSTNAME_FQDN}"
 
 # For runner to connect to.
+# Token can be found at ${GITLAB_WEB_URL}/admin/runners
 export GITLAB_TOKEN="TOKEN"
 
 

--- a/env.local.example
+++ b/env.local.example
@@ -9,6 +9,12 @@ export HOSTNAME_FQDN="hostname.domainname" # Fully qualified domain name of this
 # after database is created and seeded won't yield any change.
 export INITIAL_ROOT_PASSWORD="rootpasswd"
 
+# For runner to connect to.
+export GITLAB_WEB_URL="http://${HOSTNAME_FQDN}"
+
+# For runner to connect to.
+export GITLAB_TOKEN="TOKEN"
+
 
 #############################################################################
 # Optional vars

--- a/register-runner
+++ b/register-runner
@@ -1,6 +1,7 @@
 #!/bin/sh -x
+# https://docs.gitlab.com/runner/register/#one-line-registration-command
 #
-# To execute after first `docker-compose-wrapper.sh up -d`
+# To execute after first `docker-compose-wrapper.sh up -d`.
 
 set +x  # hide password
 # Get GITLAB_WEB_URL, GITLAB_TOKEN

--- a/register-runner
+++ b/register-runner
@@ -1,0 +1,18 @@
+#!/bin/sh -x
+#
+# To execute after first `docker-compose-wrapper.sh up -d`
+
+# Get GITLAB_WEB_URL, GITLAB_TOKEN
+. env.local
+
+docker exec gitlab-runner register \
+  --non-interactive \
+  --executor "docker" \
+  --docker-image alpine:latest \
+  --url "${GITLAB_WEB_URL}" \
+  --registration-token "${GITLAB_TOKEN}" \
+  --description "docker-runner1" \
+  --tag-list "docker,runner,runner1,docker-runner1" \
+  --run-untagged="true" \
+  --locked="false" \
+  --access-level="not_protected"

--- a/register-runner
+++ b/register-runner
@@ -2,10 +2,12 @@
 #
 # To execute after first `docker-compose-wrapper.sh up -d`
 
+set +x  # hide password
 # Get GITLAB_WEB_URL, GITLAB_TOKEN
-. env.local
+. ./env.local
+set -x
 
-docker exec gitlab-runner register \
+docker exec gitlab-runner gitlab-runner register \
   --non-interactive \
   --executor "docker" \
   --docker-image alpine:latest \

--- a/scripts/backup-datavolume.sh
+++ b/scripts/backup-datavolume.sh
@@ -1,17 +1,31 @@
 #!/bin/sh -x
-# Backup DATA_VOL_NAME to BACKUP_OUT_DIR/DATA_VOL_NAME.tgz
+# Backup/restore DATA_VOL_NAME to/from BACKUP_OUT_DIR/DATA_VOL_NAME.tgz
 
 DATA_VOL_NAME="$1"; shift
 BACKUP_OUT_DIR="$1"; shift
+MODE="$1"  # empty or value of RESTORE_MODE
+RESTORE_MODE="restore"
 
-echo "Will create $BACKUP_OUT_DIR/$DATA_VOL_NAME.tgz"
+if [ x"$MODE" != x"$RESTORE_MODE" ]; then
+    MODE_MSG="create"
+    VOLUME_MOUNT_OPT="ro"
+    TAR_OPT="c"
+    TAR_OPT2="."
+else
+    MODE_MSG="restore from"
+    VOLUME_MOUNT_OPT="rw"
+    TAR_OPT="x"
+    TAR_OPT2=""
+fi
+
+echo "Will $MODE_MSG $BACKUP_OUT_DIR/$DATA_VOL_NAME.tgz"
 
 docker run --rm \
   --name backup_data_vol_$DATA_VOL_NAME \
   -u root \
   -v $BACKUP_OUT_DIR:/backups \
-  -v $DATA_VOL_NAME:/data_vol_to_backup:ro \
+  -v $DATA_VOL_NAME:/data_vol_to_backup:$VOLUME_MOUNT_OPT \
   bash \
-  tar czf /backups/$DATA_VOL_NAME.tgz -C /data_vol_to_backup .
+  tar ${TAR_OPT}zf /backups/$DATA_VOL_NAME.tgz -C /data_vol_to_backup $TAR_OPT2
 
 # vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/scripts/backup-datavolume.sh
+++ b/scripts/backup-datavolume.sh
@@ -16,6 +16,10 @@ else
     VOLUME_MOUNT_OPT="rw"
     TAR_OPT="x"
     TAR_OPT2=""
+
+    # delete old volume for fresh restore
+    docker volume rm $DATA_VOL_NAME
+    docker volume create $DATA_VOL_NAME
 fi
 
 echo "Will $MODE_MSG $BACKUP_OUT_DIR/$DATA_VOL_NAME.tgz"

--- a/scripts/backup-gitlab.sh
+++ b/scripts/backup-gitlab.sh
@@ -1,9 +1,11 @@
 #!/bin/sh -x
-# Backup to
+# Backup to or restore from
 # * /tmp/gitlab_data_persistence.tgz
 # * /tmp/gitlab_logs_persistence.tgz
 # * /tmp/gitlab_config_persistence.tgz
 # with default values.
+#
+# Restore usage: BACKUP_OUT_DIR=/some/dir backup-gitlab.sh restore
 
 cd `dirname "$0"`/..
 
@@ -17,7 +19,7 @@ if [ -z "$DOCKER_USER_PERSISTENCE_VOLUMES" ]; then
 fi
 
 for vol in $DOCKER_USER_PERSISTENCE_VOLUMES; do
-    scripts/backup-datavolume.sh "$vol" "$BACKUP_OUT_DIR"
+    scripts/backup-datavolume.sh "$vol" "$BACKUP_OUT_DIR" "$@"
 done
 
 for vol in $DOCKER_USER_PERSISTENCE_VOLUMES; do

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -8,6 +8,7 @@ if [ ! -f env.local ]; then
 
 # override with values needed for vagrant
 export HOSTNAME_FQDN='${VM_HOSTNAME}.$VM_DOMAIN'
+export GITLAB_WEB_URL='http://${HOSTNAME_FQDN}'
 EOF
 else
     echo "existing env.local file, not overriding"

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -8,6 +8,7 @@ if [ ! -f env.local ]; then
 
 # override with values needed for vagrant
 export HOSTNAME_FQDN='${VM_HOSTNAME}.$VM_DOMAIN'
+# Refine because GITLAB_WEB_URL depends on HOSTNAME_FQDN.
 export GITLAB_WEB_URL='http://${HOSTNAME_FQDN}'
 EOF
 else


### PR DESCRIPTION
With Gitlab Pages we basically have the equivalent of privately hosted ReadTheDocs for our private internal documentation needs, see https://pages.gitlab.io/sphinx/.

So I only wanted Pages but I ended up having to enable Runner as well since Pages need to be generated through a build pipeline, even for static html.

So the bulk of this PR is actually not about activating Pages but about adding Runner and especially the semi automated way to register runner to ease the provisioning burden.

FYI @dbyrns if ever this is useful for CRIM.