### PR TITLE
Enable SSL for the main Gitlab app only, Pages still unencrypted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ ubuntu-bionic-18.04-cloudimg-console.log
 vagrant_variables.yml
 **.swp
 env.local
+
+# store real ssl cert since self-signed cert to not work well
+ssl_cert/
+
+# store backup from scripts/backup-gitlab.sh here
+gitlab-backup/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Deploy gitlab-ce using docker-compose
   host.
 
 * Ensure you have a valid Wildcard SSL Certificate for your host.  The Wildcard
-  requirement is for Gitlab Pages.
+  requirement is for Gitlab Pages.  Get a real SSL Certificate, support for
+  self-signed SSL Certificate is not fully implemented.
 
 * Gitlab Pages needs "wildcard DNS" to be setup for this Gitlab host, see
 https://docs.gitlab.com/ee/administration/pages/index.html#dns-configuration.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Deploy gitlab-ce using docker-compose
   [docker-compose](https://docs.docker.com/compose/) installed on your Linux
   host.
 
+* Ensure you have a valid Wildcard SSL Certificate for your host.  The Wildcard
+  requirement is for Gitlab Pages.
+
 * Gitlab Pages needs "wildcard DNS" to be setup for this Gitlab host, see
 https://docs.gitlab.com/ee/administration/pages/index.html#dns-configuration.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'https://${HOSTNAME_FQDN}'
 
+        # https://docs.gitlab.com/omnibus/settings/nginx.html#setting-http-strict-transport-security
+        # https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/
+        # nginx['hsts_max_age'] = 0  # 0 disable HSTS, for self-signed SSL cert only
+
         # https://docs.gitlab.com/12.10/ee/administration/pages/index.html#wildcard-domains
         # pages will be available at http://<USER or GROUP>.${HOSTNAME_FQDN}/<REPO>
         # TODO: switch to httpS for Pages once we have Wildcard SSL Cert.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,11 @@ services:
     environment:
       # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://${HOSTNAME_FQDN}'
+        external_url 'https://${HOSTNAME_FQDN}'
 
         # https://docs.gitlab.com/12.10/ee/administration/pages/index.html#wildcard-domains
         # pages will be available at http://<USER or GROUP>.${HOSTNAME_FQDN}/<REPO>
+        # TODO: switch to httpS for Pages once we have Wildcard SSL Cert.
         pages_external_url 'http://${HOSTNAME_FQDN}'
         pages_nginx['redirect_http_to_https'] = false
         gitlab_pages['inplace_chroot'] = true
@@ -42,6 +43,8 @@ services:
       - 'gitlab_config_persistence:/etc/gitlab'
       - 'gitlab_logs_persistence:/var/log/gitlab'
       - 'gitlab_data_persistence:/var/opt/gitlab'
+      - '${SSL_CERTIFICATE}:/etc/gitlab/ssl/${HOSTNAME_FQDN}.crt:ro'
+      - '${SSL_CERTIFICATE_KEY}:/etc/gitlab/ssl/${HOSTNAME_FQDN}.key:ro'
 
   gitlab-runner:
     image: 'gitlab/gitlab-runner:v14.7.0'

--- a/env.local.example
+++ b/env.local.example
@@ -3,6 +3,8 @@
 # Can add new vars but do not remove, else automated deployment will break
 #############################################################################
 
+export SSL_CERTIFICATE="/path/to/ssl/cert.crt"  # *absolute* path, .pem works too
+export SSL_CERTIFICATE_KEY="/path/to/ssl/cert.key"  # *absolute* path
 export HOSTNAME_FQDN="hostname.domainname" # Fully qualified domain name of this installation
 
 # Only applicable on initial setup, changing these settings
@@ -10,7 +12,7 @@ export HOSTNAME_FQDN="hostname.domainname" # Fully qualified domain name of this
 export INITIAL_ROOT_PASSWORD="rootpasswd"
 
 # For runner to connect to.
-export GITLAB_WEB_URL="http://${HOSTNAME_FQDN}"
+export GITLAB_WEB_URL="https://${HOSTNAME_FQDN}"
 
 # For runner to connect to.
 # Token can be found at ${GITLAB_WEB_URL}/admin/runners, login using root account.

--- a/env.local.example
+++ b/env.local.example
@@ -12,6 +12,7 @@ export HOSTNAME_FQDN="hostname.domainname" # Fully qualified domain name of this
 export INITIAL_ROOT_PASSWORD="rootpasswd"
 
 # For runner to connect to.
+# Note: runner is unable to register if GITLAB_WEB_URL uses self-signed ssl certificate.
 export GITLAB_WEB_URL="https://${HOSTNAME_FQDN}"
 
 # For runner to connect to.

--- a/register-runner
+++ b/register-runner
@@ -3,6 +3,8 @@
 #
 # To execute after first `docker-compose-wrapper.sh up -d`.
 
+# NOTE: register step do not work when GITLAB_WEB_URL uses self-signed cert.
+
 set +x  # hide password
 # Get GITLAB_WEB_URL, GITLAB_TOKEN
 . ./env.local

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -2,6 +2,17 @@
 
 cd /vagrant
 
+if [ -f ./env.local ]; then
+    # Get SSL_CERTIFICATE, SSL_CERTIFICATE_KEY from existing env.local.
+    . ./env.local
+fi
+
+if [ ! -f "$SSL_CERTIFICATE" -a ! -f "$SSL_CERTIFICATE_KEY" ]; then
+    # If both have bogus value, set appropriate one for Vagrant.
+    SSL_CERTIFICATE="/home/vagrant/cert.pem"
+    SSL_CERTIFICATE_KEY="/home/vagrant/key.pem"
+fi
+
 if [ ! -f env.local ]; then
     cp env.local.example env.local
     cat <<EOF >> env.local
@@ -9,8 +20,22 @@ if [ ! -f env.local ]; then
 # override with values needed for vagrant
 export HOSTNAME_FQDN='${VM_HOSTNAME}.$VM_DOMAIN'
 # Refine because GITLAB_WEB_URL depends on HOSTNAME_FQDN.
-export GITLAB_WEB_URL='http://${HOSTNAME_FQDN}'
+export GITLAB_WEB_URL='https://${HOSTNAME_FQDN}'
+
+export SSL_CERTIFICATE="$SSL_CERTIFICATE"
+export SSL_CERTIFICATE_KEY="$SSL_CERTIFICATE_KEY"
+
 EOF
 else
     echo "existing env.local file, not overriding"
+fi
+
+if [ ! -f "$SSL_CERTIFICATE" -a ! -f "$SSL_CERTIFICATE_KEY" ]; then
+    . ./env.local
+    openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 \
+        -keyout "$SSL_CERTIFICATE_KEY" \
+        -out "$SSL_CERTIFICATE" \
+	-subj "/C=CA/ST=Quebec/L=Montreal/O=RnD/CN=*.${VM_HOSTNAME}.$VM_DOMAIN"
+else
+    echo "existing '$SSL_CERTIFICATE' or '$SSL_CERTIFICATE_KEY' file, not overriding"
 fi

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -22,7 +22,7 @@ if [ ! -f env.local ]; then
 # override with values needed for vagrant
 export HOSTNAME_FQDN='${VM_HOSTNAME}.$VM_DOMAIN'
 # Refine because GITLAB_WEB_URL depends on HOSTNAME_FQDN.
-export GITLAB_WEB_URL='https://\${HOSTNAME_FQDN}'
+export GITLAB_WEB_URL="https://\${HOSTNAME_FQDN}"
 
 export SSL_CERTIFICATE="$SSL_CERTIFICATE"
 export SSL_CERTIFICATE_KEY="$SSL_CERTIFICATE_KEY"

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -1,4 +1,6 @@
 #!/bin/sh -x
+#
+# Test: VM_HOSTNAME=host VM_DOMAIN=dom.main ./vagrant-provisioning/provision.sh
 
 cd /vagrant
 
@@ -20,7 +22,7 @@ if [ ! -f env.local ]; then
 # override with values needed for vagrant
 export HOSTNAME_FQDN='${VM_HOSTNAME}.$VM_DOMAIN'
 # Refine because GITLAB_WEB_URL depends on HOSTNAME_FQDN.
-export GITLAB_WEB_URL='https://${HOSTNAME_FQDN}'
+export GITLAB_WEB_URL='https://\${HOSTNAME_FQDN}'
 
 export SSL_CERTIFICATE="$SSL_CERTIFICATE"
 export SSL_CERTIFICATE_KEY="$SSL_CERTIFICATE_KEY"

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -41,3 +41,10 @@ if [ ! -f "$SSL_CERTIFICATE" -a ! -f "$SSL_CERTIFICATE_KEY" ]; then
 else
     echo "existing '$SSL_CERTIFICATE' or '$SSL_CERTIFICATE_KEY' file, not overriding"
 fi
+
+
+sudo apt update
+sudo apt install docker.io docker-compose
+
+# Start the whole stack.
+./docker-compose-wrapper.sh up -d

--- a/vagrant-provisioning/provision.sh
+++ b/vagrant-provisioning/provision.sh
@@ -46,5 +46,14 @@ fi
 sudo apt update
 sudo apt install docker.io docker-compose
 
+# Add current user to group docker to not have to always do 'sudo docker'
+sudo usermod -a -G docker $USER
+if [ -n "`df -h | grep ^vagrant`" ]; then
+    # inside a vagrant box, add user 'vagrant' to group docker for the same reason
+    # $USER was 'root', not 'vagrant', during provisionning step
+    sudo usermod -a -G docker vagrant
+fi
+
+
 # Start the whole stack.
 ./docker-compose-wrapper.sh up -d


### PR DESCRIPTION
Pages still unencrypted because it requires a Wildcard SSL Certificate that we do not have yet.

On test systems, self-signed SSL cert not working, have to use a real cert.

Vagrant will attempt to provision a wildcard self-signed cert if a real one is not given, at least the main app will work but runner will not be able to connect.

Fix `vagrant up` did not start the whole stack.