### PR TITLE
Enable SSL for Gitlab Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Deploy gitlab-ce using docker-compose
 
 * Ensure you have a valid Wildcard SSL Certificate for your host.  The Wildcard
   requirement is for Gitlab Pages.  Get a real SSL Certificate, support for
-  self-signed SSL Certificate is not fully implemented.
+  self-signed SSL Certificate is not fully implemented.  If using self-signed
+  SSL Certificate, only the main Gitlab webapp will work properly.  Gitlab Pages
+  will not work because unable to register the runner against main webapp
+  behind self-signed SSL Certificate.
 
 * Gitlab Pages needs "wildcard DNS" to be setup for this Gitlab host, see
 https://docs.gitlab.com/ee/administration/pages/index.html#dns-configuration.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,9 @@ services:
         # nginx['hsts_max_age'] = 0  # 0 disable HSTS, for self-signed SSL cert only
 
         # https://docs.gitlab.com/12.10/ee/administration/pages/index.html#wildcard-domains
-        # pages will be available at http://<USER or GROUP>.${HOSTNAME_FQDN}/<REPO>
-        # TODO: switch to httpS for Pages once we have Wildcard SSL Cert.
-        pages_external_url 'http://${HOSTNAME_FQDN}'
-        pages_nginx['redirect_http_to_https'] = false
+        # pages will be available at https://<USER or GROUP>.${HOSTNAME_FQDN}/<REPO>
+        pages_external_url 'https://${HOSTNAME_FQDN}'
+        pages_nginx['redirect_http_to_https'] = true
         gitlab_pages['inplace_chroot'] = true
 
         # rather not take over the really ssh port 22 of the host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'https://${HOSTNAME_FQDN}'
+        nginx['redirect_http_to_https'] = true
 
         # https://docs.gitlab.com/omnibus/settings/nginx.html#setting-http-strict-transport-security
         # https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/


### PR DESCRIPTION
Enable ssl for gitlab pages now that production has a proper wildcard SSL certificate.

Better documentation why gitlab pages do not work properly with self-signed SSL cert.

Enable redirect from http to httpS for the main webapp, same as for gitlab pages.